### PR TITLE
feat: Add Jenkins staging and production applications

### DIFF
--- a/argocd-apps/jenkins-prod-app.yaml
+++ b/argocd-apps/jenkins-prod-app.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: jenkins-dev
+  name: jenkins-prod
   namespace: argocd
 spec:
   project: jenkins
@@ -11,10 +11,10 @@ spec:
     path: base/jenkins
     helm:
       valueFiles:
-        - ../../dev/values.yaml
+        - ../../production/values.yaml
   destination:
     server: https://kubernetes.default.svc
-    namespace: jenkins-dev
+    namespace: jenkins-prod
   syncPolicy:
     automated:
       prune: true

--- a/argocd-apps/jenkins-staging-app.yaml
+++ b/argocd-apps/jenkins-staging-app.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: jenkins-dev
+  name: jenkins-staging
   namespace: argocd
 spec:
   project: jenkins
@@ -11,10 +11,10 @@ spec:
     path: base/jenkins
     helm:
       valueFiles:
-        - ../../dev/values.yaml
+        - ../../staging/values.yaml
   destination:
     server: https://kubernetes.default.svc
-    namespace: jenkins-dev
+    namespace: jenkins-staging
   syncPolicy:
     automated:
       prune: true

--- a/production/values.yaml
+++ b/production/values.yaml
@@ -1,0 +1,61 @@
+# Name: production/values.yaml
+# Purpose: Provide Helm values customized for the Production Jenkins env
+# Description: Overrides Jenkins image, JVM opts, and JCasC env variables
+
+controller:
+  image:
+    # Using the official public Jenkins LTS image as a placeholder.
+    repository: "jenkins/jenkins"
+    tag: "lts-jdk17"
+    pullPolicy: "Always"
+
+# Defining resource requests and limits for the production environment.
+resources:
+  requests:
+    cpu: "2000m"
+    memory: "4Gi"
+  limits:
+    cpu: "4000m"
+    memory: "8Gi"
+
+jenkinsJavaOpts: "-Xms4g -Xmx6g"
+
+jenkinsEnvVars:
+  JCASC_SYSTEM_MESSAGE: "Welcome to Jenkins (Production Environment)"
+  JCASC_LOCATION_URL: ""
+  JCASC_LOCATION_ADMINADDRESS: "prod-admin@example.com"
+  JCASC_MASTER_LABELS: "prod-controller"
+  JCASC_RESOURCE_ROOT_URL: ""
+  JCASC_DISABLE_DEFERRED_WIPEOUT: "false"
+  JCASC_SCM_POLLING_THREADCOUNT: "10"
+
+  JCASC_PROXY_HOST: ""
+  JCASC_PROXY_PORT: ""
+  JCASC_PROXY_USERNAME: ""
+  JCASC_PROXY_NOPROXY: ""
+
+  JCASC_FINGERPRINT_STORAGE: ""
+  JCASC_FINGERPRINT_CLEANUP_PERIOD: ""
+
+  JCASC_MAILER_SMTP_HOST: ""
+  JCASC_MAILER_SMTP_PORT: ""
+  JCASC_MAILER_USE_SSL: "false"
+  JCASC_MAILER_USE_TLS: "false"
+  JCASC_MAILER_SMTP_USERNAME: ""
+  JCASC_MAILER_DEFAULT_SUFFIX: ""
+  JCASC_MAILER_CHARSET: "UTF-8"
+
+  JCASC_JENKINSGLOBALENVVARS_LOGLEVEL: ""
+  JCASC_JENKINSGLOBALENVVARS_ARTIFACTORYURL: ""
+  JCASC_JENKINSGLOBALENVVARS_DOCKERREGISTRY: ""
+  JCASC_JENKINSGLOBALENVVARS_GERRITURLBASE: ""
+  JCASC_JENKINSGLOBALENVVARS_GITBASEURL: ""
+  JCASC_JENKINSGLOBALENVVARS_GITURL: ""
+  JCASC_JENKINSGLOBALENVVARS_PACKAGECLOUDPROXY: ""
+  JCASC_JENKINSGLOBALENVVARS_PCIOCO: ""
+  JCASC_JENKINSGLOBALENVVARS_RELEASEEMAIL: ""
+  JCASC_JENKINSGLOBALENVVARS_RELEASEUSERNAME: ""
+  JCASC_JENKINSGLOBALENVVARS_S3BUCKET: ""
+  JCASC_JENKINSGLOBALENVVARS_CDNURL: ""
+  JCASC_JENKINSGLOBALENVVARS_SIGULKEY: ""
+  JCASC_JENKINSGLOBALENVVARS_SILO: "production"

--- a/staging/values.yaml
+++ b/staging/values.yaml
@@ -1,0 +1,61 @@
+# Name: staging/values.yaml
+# Purpose: Provide Helm values customized for the Staging Jenkins env
+# Description: Overrides Jenkins image, JVM opts, and JCasC env variables
+
+controller:
+  image:
+    # Using the official public Jenkins LTS image as a placeholder.
+    repository: "jenkins/jenkins"
+    tag: "lts-jdk17"
+    pullPolicy: "IfNotPresent"
+
+# Defining resource requests and limits for the staging environment.
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2Gi"
+  limits:
+    cpu: "2000m"
+    memory: "4Gi"
+
+jenkinsJavaOpts: "-Xms1g -Xmx2g"
+
+jenkinsEnvVars:
+  JCASC_SYSTEM_MESSAGE: "Welcome to Jenkins (Staging Environment)"
+  JCASC_LOCATION_URL: ""
+  JCASC_LOCATION_ADMINADDRESS: "staging-admin@example.com"
+  JCASC_MASTER_LABELS: "staging-controller"
+  JCASC_RESOURCE_ROOT_URL: ""
+  JCASC_DISABLE_DEFERRED_WIPEOUT: "false"
+  JCASC_SCM_POLLING_THREADCOUNT: "5"
+
+  JCASC_PROXY_HOST: ""
+  JCASC_PROXY_PORT: ""
+  JCASC_PROXY_USERNAME: ""
+  JCASC_PROXY_NOPROXY: ""
+
+  JCASC_FINGERPRINT_STORAGE: ""
+  JCASC_FINGERPRINT_CLEANUP_PERIOD: ""
+
+  JCASC_MAILER_SMTP_HOST: ""
+  JCASC_MAILER_SMTP_PORT: ""
+  JCASC_MAILER_USE_SSL: "false"
+  JCASC_MAILER_USE_TLS: "false"
+  JCASC_MAILER_SMTP_USERNAME: ""
+  JCASC_MAILER_DEFAULT_SUFFIX: ""
+  JCASC_MAILER_CHARSET: "UTF-8"
+
+  JCASC_JENKINSGLOBALENVVARS_LOGLEVEL: ""
+  JCASC_JENKINSGLOBALENVVARS_ARTIFACTORYURL: ""
+  JCASC_JENKINSGLOBALENVVARS_DOCKERREGISTRY: ""
+  JCASC_JENKINSGLOBALENVVARS_GERRITURLBASE: ""
+  JCASC_JENKINSGLOBALENVVARS_GITBASEURL: ""
+  JCASC_JENKINSGLOBALENVVARS_GITURL: ""
+  JCASC_JENKINSGLOBALENVVARS_PACKAGECLOUDPROXY: ""
+  JCASC_JENKINSGLOBALENVVARS_PCIOCO: ""
+  JCASC_JENKINSGLOBALENVVARS_RELEASEEMAIL: ""
+  JCASC_JENKINSGLOBALENVVARS_RELEASEUSERNAME: ""
+  JCASC_JENKINSGLOBALENVVARS_S3BUCKET: ""
+  JCASC_JENKINSGLOBALENVVARS_CDNURL: ""
+  JCASC_JENKINSGLOBALENVVARS_SIGULKEY: ""
+  JCASC_JENKINSGLOBALENVVARS_SILO: "staging"


### PR DESCRIPTION
 - Creates the ArgoCD application manifests for staging and production
 - Modifies the app of apps application name to argocd-apps
 - Adds JCasC Helm values for each environment
 - Using the public Jenkins LTS image as a placeholder. Will be replaced with a custom image built from the incoming action
 - Tests will be provided in a separate patch