### PR TITLE
fix: prevent GHCR push when running from a fork

### DIFF
--- a/.github/workflows/build-jenkins-image.yml
+++ b/.github/workflows/build-jenkins-image.yml
@@ -38,5 +38,6 @@ jobs:
           docker rm -f jenkins-test
 
       - name: Push Jenkins image to GHCR
+        if: github.repository == 'lfit/jenkins-gitops'
         run: |
           docker push ghcr.io/lfit/jenkins:main


### PR DESCRIPTION
- Adds a repository check to only push image if workflow runs in lfit/jenkins-gitops
- Prevents permission errors during CI in forks
- Keeps GHCR publishing restricted to trusted upstream runs